### PR TITLE
fix: remove unnecessary length fields from structs

### DIFF
--- a/include/cbreader/rmesh.h
+++ b/include/cbreader/rmesh.h
@@ -12,7 +12,6 @@ constexpr std::uint32_t MAX_SOUND_EMITTERS = 16;
 struct Header
 {
 	// Length prefixed string
-	std::uint32_t header_length = 0;
 	std::string header;
 
 	/** Defines whether or not the RMesh file has any triggers embedded within the file. */
@@ -26,7 +25,6 @@ struct Texture
 {
 	std::byte blendType;
 
-	std::uint32_t textureNameLength = 0;
 	std::string textureName;
 };
 
@@ -35,31 +33,27 @@ struct Vertex
 	Vector3 vertex;
 	Vector2 uv;
 
-	float unk1;
-	float unk2;
+	float unk1{};
+	float unk2{};
 
-	std::byte r;
-	std::byte g;
-	std::byte b;
+	std::byte r{};
+	std::byte g{};
+	std::byte b{};
 };
 
 struct Surface
 {
 	Texture textures[2];
 
-	std::uint32_t vertexCount = 0;
 	std::vector<Vertex> vertices;
 
-	std::uint32_t trianglesCount = 0;
 	std::vector<Triangle> triangles;
 };
 
 struct Mesh
 {
-	std::int32_t surfaceCount;
 	std::vector<Surface> surfaces;
 
-	std::uint32_t nameLength = 0;
 	std::string name;
 };
 
@@ -70,7 +64,6 @@ struct Mesh
 */
 struct Entity
 {
-	std::uint32_t classNameLength = 0;
 	std::string className;
 
 	/** This is read per entity. It would be ideal to read it in Entity, but EntityModel is special in that it has the model file name THEN the position. */
@@ -78,67 +71,62 @@ struct Entity
 	Vector3 rotation;
 	Vector3 scale;
 
-	virtual void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className);
+	virtual void Read(BufferStream& stream, std::string _className);
 };
 
-struct EntityScreen : Entity
+struct EntityScreen : public Entity
 {
-	std::uint32_t imgPathLength = 0;
 	std::string imgPath;
 
-	virtual void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className);
+	void Read(BufferStream& stream, std::string _className) override;
 };
 
-struct EntityWaypoint : Entity
+struct EntityWaypoint : public Entity
 {
-	virtual void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className);
+	void Read(BufferStream& stream, std::string _className) override;
 };
 
-struct EntityLight : Entity
+struct EntityLight : public Entity
 {
 	/** SCP:CB calculates this as range/2000.0 in the RMesh code*/
 	float range = 0.f;
 
 	/** Space delimited color string. Color is 3 ints, and multiplied by intensity when reading. */
-	std::uint32_t colorLength = 0;
 	std::string color;
 
 	/** SCP:CB calculates this as Min(intensity*0.8,1)*/
 	float intensity = 0.f;
 
-	virtual void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className);
+	void Read(BufferStream& stream, std::string _className) override;
 };
 
-struct EntitySpotLight : EntityLight
+struct EntitySpotLight : public EntityLight
 {
-	std::uint32_t anglesLength = 0;
 	std::string angles;
 
 	std::uint32_t innerConeAngle = 0;
 	std::uint32_t outerConeAngle = 0;
 
-	virtual void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className);
+	void Read(BufferStream& stream, std::string _className) override;
 };
 
-struct EntitySoundEmitter : Entity
+struct EntitySoundEmitter : public Entity
 {
-	virtual void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className);
+	void Read(BufferStream& stream, std::string _className) override;
 };
 
-struct EntityPlayerStart : Entity
+struct EntityPlayerStart : public Entity
 {
-	std::uint32_t anglesLength = 0;
 	std::string angles;
 
-	virtual void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className);
+	void Read(BufferStream& stream, std::string _className) override;
 };
 
-struct EntityModel : Entity
+struct EntityModel : public Entity
 {
-	std::uint32_t pathLength = 0;
 	std::string path;
 
-	void Read(BufferStream stream, std::uint32_t _classNameLength, std::string _className) override;
+	void Read(BufferStream& stream, std::string _className) override;
 };
 
 /**
@@ -154,10 +142,8 @@ struct RMesh
 	Mesh drawnMesh;
 	Mesh collisionMesh;
 
-	std::uint32_t triggerBoxCount = 0;
 	std::vector<Mesh> triggerBoxes;
 
-	std::uint32_t entityCount = 0;
 	std::vector<Entity> entities;
 
 	/**
@@ -169,6 +155,6 @@ struct RMesh
 	*/
 	bool Read(const std::string& path);
 
-	Mesh ReadDrawnMesh(BufferStream& stream);
-	Mesh ReadCollisionMesh(BufferStream& stream);
+	static Mesh ReadDrawnMesh(BufferStream& stream);
+	static Mesh ReadCollisionMesh(BufferStream& stream);
 };

--- a/test/test_rmesh.cpp
+++ b/test/test_rmesh.cpp
@@ -17,33 +17,33 @@ TEST(RMesh, read_triggerboxes)
 	EXPECT_STREQ(rmesh.header.header.data(), "RoomMesh.HasTriggerBox");
 
 	// Length of the header string.
-	EXPECT_EQ(rmesh.header.header_length, 22);
+	EXPECT_EQ(rmesh.header.header.size(), 22);
 
 	// This RMesh file should have trigger boxes but not "hasNoColl"
 	EXPECT_TRUE(rmesh.header.hasTriggerBox);
 	EXPECT_FALSE(rmesh.header.hasNoColl);
 
-	EXPECT_EQ(rmesh.drawnMesh.surfaceCount, 22);
+	EXPECT_EQ(rmesh.drawnMesh.surfaces.size(), 22);
 
 	// Test both the first and second index, if these pass the rest should be fine
 
 	// The first texture index usually contains the texture. Each "surface" is a section of the mesh that all uses the same texture
-	EXPECT_EQ(rmesh.drawnMesh.surfaces[0].textures[1].textureNameLength, 21);
+	EXPECT_EQ(rmesh.drawnMesh.surfaces[0].textures[1].textureName.size(), 21);
 	EXPECT_STREQ(rmesh.drawnMesh.surfaces[0].textures[1].textureName.data(), "containment_doors.jpg");
 
-	EXPECT_EQ(rmesh.drawnMesh.surfaces[0].vertexCount, 318);
-	EXPECT_EQ(rmesh.drawnMesh.surfaces[0].trianglesCount, 352);
+	EXPECT_EQ(rmesh.drawnMesh.surfaces[0].vertices.size(), 318);
+	EXPECT_EQ(rmesh.drawnMesh.surfaces[0].triangles.size(), 352);
 
-	EXPECT_EQ(rmesh.drawnMesh.surfaces[1].textures[1].textureNameLength, 9);
+	EXPECT_EQ(rmesh.drawnMesh.surfaces[1].textures[1].textureName.size(), 9);
 	EXPECT_STREQ(rmesh.drawnMesh.surfaces[1].textures[1].textureName.data(), "metal.jpg");
 
-	EXPECT_EQ(rmesh.drawnMesh.surfaces[1].vertexCount, 9994);
-	EXPECT_EQ(rmesh.drawnMesh.surfaces[1].trianglesCount, 5104);
+	EXPECT_EQ(rmesh.drawnMesh.surfaces[1].vertices.size(), 9994);
+	EXPECT_EQ(rmesh.drawnMesh.surfaces[1].triangles.size(), 5104);
 
 	// Test the collision model, if we got this passes then it's safe to assume the drawn mesh was read fine.
-	EXPECT_EQ(rmesh.collisionMesh.surfaceCount, 1);
-	EXPECT_EQ(rmesh.collisionMesh.surfaces[0].vertexCount, 18);
-	EXPECT_EQ(rmesh.collisionMesh.surfaces[0].trianglesCount, 8);
+	EXPECT_EQ(rmesh.collisionMesh.surfaces.size(), 1);
+	EXPECT_EQ(rmesh.collisionMesh.surfaces[0].vertices.size(), 18);
+	EXPECT_EQ(rmesh.collisionMesh.surfaces[0].triangles.size(), 8);
 }
 
 /** Reads an RMesh file from the SCP: NTF Mod. This file incorporates hasNoColl in the header. */


### PR DESCRIPTION
I figured I could improve the code a teensy bit

- Removed length fields where they were equivalent to the string or vector length
- Pedantic stuff that was mostly my personal preference:
  - Use concatenated reads where possible
  - Use read method which accepts a reference where possible
  - Use skip over read when value is unused

Feel free to close ( :wastebasket: ) or edit